### PR TITLE
fix NCO bug868

### DIFF
--- a/Conf/Nemsio_gnu_General.sh
+++ b/Conf/Nemsio_gnu_General.sh
@@ -10,7 +10,7 @@
 
  ANCHORDIR=..
  export COMP=gnu/impi
- export NEMSIO_VER=v2.2.4
+ export NEMSIO_VER=v2.2.5
  export NEMSIO_SRC=
  export NEMSIO_INC=$ANCHORDIR/${COMP#*/}/include/nemsio_${NEMSIO_VER}
  export NEMSIO_LIB=$ANCHORDIR/${COMP#*/}/libnemsio_${NEMSIO_VER}.a

--- a/Conf/Nemsio_intel_Cray.sh
+++ b/Conf/Nemsio_intel_Cray.sh
@@ -3,7 +3,7 @@
  module load intel/18.1.163
  
  module load nemsio-intel/2.2.3
- new_ver=v2.2.4
+ new_ver=v2.2.5
  reset_version nemsio $new_ver
 
  export CC=icc

--- a/Conf/Nemsio_intel_Dell.sh
+++ b/Conf/Nemsio_intel_Dell.sh
@@ -5,7 +5,7 @@
  module load impi/18.0.1
 
  module load nemsio/2.2.3
- new_ver=v2.2.4
+ new_ver=v2.2.5
  reset_version nemsio $new_ver
 
  export CC=icc

--- a/Conf/Nemsio_intel_General.sh
+++ b/Conf/Nemsio_intel_General.sh
@@ -16,7 +16,7 @@
 
  ANCHORDIR=..
  export COMP=ips/impi
- export NEMSIO_VER=v2.2.4
+ export NEMSIO_VER=v2.2.5
  export NEMSIO_SRC=
  export NEMSIO_INC=$ANCHORDIR/${COMP#*/}/include/nemsio_${NEMSIO_VER}
  export NEMSIO_LIB=$ANCHORDIR/${COMP#*/}/libnemsio_${NEMSIO_VER}.a

--- a/Conf/Nemsio_intel_Theia.sh
+++ b/Conf/Nemsio_intel_Theia.sh
@@ -5,7 +5,7 @@
  module load EnvVars/1.0.2
  module load ips/18.0.1.163
  module load impi/2018.0.1
- module load dev/nemsio/2.2.4
+ module load dev/nemsio/2.2.5
 
  export CC=icc
  export FC=ifort

--- a/Conf/Nemsio_intel_Wcoss.sh
+++ b/Conf/Nemsio_intel_Wcoss.sh
@@ -3,7 +3,7 @@
  module load ics/17.0.3
 
  module load nemsio/v2.2.3
- new_ver=v2.2.4
+ new_ver=v2.2.5
  reset_version nemsio $new_ver
 
  export CC=icc

--- a/readme
+++ b/readme
@@ -18,17 +18,17 @@ modulefiles
 
 ================================================
 -------------
-Adjust to NCO format for version v2.2.4
+Adjust to NCO format for version v2.2.5
 on WCOSS-Phase 1/2 and theia
 ----------------------------------------------
-lib/nemsio/v2.2.4
+lib/nemsio/v2.2.5
             |
             `--src
             `--modulefiles
             |     |
-            |     `--v2.2.4
+            |     `--v2.2.5
             `--unit_test
-            `--libnemsio_v2.2.4.a
+            `--libnemsio_v2.2.5.a
             |
             `--include
                   |
@@ -39,30 +39,30 @@ lib/nemsio/v2.2.4
 
 on WCOSS-Cray
 -----------------------------------------
-lib/nemsio/v2.2.4
+lib/nemsio/v2.2.5
       |
       `--src
       `--modulefiles
       |     |
-      |     `--v2.2.4
+      |     `--v2.2.5
       `--unit_test
       `--intel
       |     |
-      |     `--libnemsio_v2.2.4.a
+      |     `--libnemsio_v2.2.5.a
       |     |
       |     `--include
       |           |
-      |           `--nemsio_v2.2.4
+      |           `--nemsio_v2.2.5
       |                    |
       |                    `--nemsio_*.mod
       |
       `--cray
             |
-            `--libnemsio_v2.2.4.a
+            `--libnemsio_v2.2.5.a
             |
             `--include
                   |
-                  `--nemsio_v2.2.4
+                  `--nemsio_v2.2.5
                            |
                            `--NEMSIO_*.mod
 
@@ -71,7 +71,7 @@ lib/nemsio/v2.2.4
 nceplibs/nemsio lib:
 
 ==================================================
-V2.2.4 Hang Lei  since version 2.2.4, the nemsio library only update on VLAB.
+V2.2.5 Hang Lei  since version 2.2.5, the nemsio library only update on VLAB.
                  In this version, the improvement is made to read extra meta data in nemsio files.
                  logical conditions is added in nemsio_openclose.f90 line 2512-2570.
 

--- a/src/nemsio_module_mpi.f90
+++ b/src/nemsio_module_mpi.f90
@@ -408,7 +408,13 @@ contains
 !------------------------------------------------------------
     call chk_endianc(machine_endian)
     if(trim(machine_endian)=='mixed_endian') then
-      call nemsio_stop('You are in mixed endian computer,stop!!!')
+       print *, 'You are in mixed endian computer!!!'
+       if ( present(iret))  then
+         iret=-1
+         return
+       else
+         call nemsio_stop
+       endif
     endif
 !
     if(present(iret)) iret=0
@@ -1219,7 +1225,12 @@ contains
     endif
     if ( gfile%idate(1).eq.nemsio_intfill) then
       print *,'idate=',gfile%idate,' WRONG: please provide idate(1:7)(yyyy/mm/dd/hh/min/secn/secd)!!!'
-      call nemsio_stop()
+!         if ( present(iret)) then
+         iret=-1
+         return
+!         else
+!         call nemsio_stop
+!         endif
     endif
 !
     if ( gfile%gtype(1:6).eq."NEMSIO" ) then

--- a/src/nemsio_openclose.f90
+++ b/src/nemsio_openclose.f90
@@ -733,8 +733,10 @@ contains
       if(trim(machine_endian)=='little_endian') gfile%do_byteswap=.false.
       call bafrreadl(gfile%flunit,iskip,iread,nread,meta1)
       if(nread<iread) then
-        print *,'WARNING: the file probably is in mixed endian, the program will STOP!'
-        call nemsio_stop()
+        print *,'nread',nread, '< iread',iread     
+        print *,'WARNING: the file probably is in mixed endian, or empty files'
+        iret=-1
+         return
       endif
 !
     elseif(.not.lreadcrt) then
@@ -1416,7 +1418,12 @@ contains
     endif
     if ( gfile%idate(1).eq.nemsio_intfill) then
       print *,'idate=',gfile%idate,' ERROR: please provide idate(1:7)(yyyy/mm/dd/hh/min/secn/secd)!!!'
-      call nemsio_stop()
+!       if (present(iret)) then
+       iret=-1
+       return
+!       else
+!       call nemsio_stop
+!       endif
     endif
 !
     if ( gfile%gtype(1:6).eq."NEMSIO" ) then
@@ -3232,7 +3239,12 @@ contains
     if(gfile%dimx.eq.nemsio_intfill.or.gfile%dimy.eq.nemsio_intfill.or. &
        gfile%dimz.eq.nemsio_intfill.or.gfile%idate(1).eq.nemsio_intfill) then
        print *,'ERROR: please provide dimensions!'
-       call nemsio_stop
+!       if (present(iret)) then
+       iret=-1
+       return
+!       else
+!       call nemsio_stop
+!       endif
     endif
     if(gfile%nframe.eq.nemsio_intfill) gfile%nframe=0
     gfile%fieldsize=(gfile%dimx+2*gfile%nframe)*(gfile%dimy+2*gfile%nframe)

--- a/unit_test/makefile
+++ b/unit_test/makefile
@@ -2,11 +2,11 @@ SHELL   =/bin/sh
 EXEC    =nemsio_read
 LIBDIR=/gpfs/hps/nco/ops/nwprod/lib
 TEST=../intel
-INCMOD=../intel/include/nemsio_v2.2.4
+INCMOD=../intel/include/nemsio_v2.2.5
 FC      =  ftn
 FOPTS  = -O -FR -I$(INCMOD)
-LIBS   =-L$(TEST) -lnemsio_v2.2.4 -L$(LIBDIR)/bacio/v2.0.1/intel -lbacio_v2.0.1_4 -L$(LIBDIR)/w3emc/v2.2.0/intel -lw3emc_v2.2.0_d -L$(LIBDIR)/w3nco/v2.0.6/intel -lw3nco_v2.0.6_d
-#LIBS   =-L$(TEST) -lnemsio_v2.2.4
+LIBS   =-L$(TEST) -lnemsio_v2.2.5 -L$(LIBDIR)/bacio/v2.0.1/intel -lbacio_v2.0.1_4 -L$(LIBDIR)/w3emc/v2.2.0/intel -lw3emc_v2.2.0_d -L$(LIBDIR)/w3nco/v2.0.6/intel -lw3nco_v2.0.6_d
+#LIBS   =-L$(TEST) -lnemsio_v2.2.5
 OBJS = read_nemsio.o
 SRCS = read_nemsio.f
 # *************************************************************************

--- a/unit_test/makefile_read_nemsio_cray_intel
+++ b/unit_test/makefile_read_nemsio_cray_intel
@@ -2,11 +2,11 @@ SHELL   =/bin/sh
 EXEC    =nemsio_read
 LIBDIR=/gpfs/hps/nco/ops/nwprod/lib
 TEST=../intel
-INCMOD=../intel/include/nemsio_v2.2.4
+INCMOD=../intel/include/nemsio_v2.2.5
 FC      =  ftn
 FOPTS  = -O -FR -I$(INCMOD)
-LIBS   =-L$(TEST) -lnemsio_v2.2.4 -L$(LIBDIR)/bacio/v2.0.1/intel -lbacio_v2.0.1_4 -L$(LIBDIR)/w3emc/v2.2.0/intel -lw3emc_v2.2.0_d -L$(LIBDIR)/w3nco/v2.0.6/intel -lw3nco_v2.0.6_d
-#LIBS   =-L$(TEST) -lnemsio_v2.2.4
+LIBS   =-L$(TEST) -lnemsio_v2.2.5 -L$(LIBDIR)/bacio/v2.0.1/intel -lbacio_v2.0.1_4 -L$(LIBDIR)/w3emc/v2.2.0/intel -lw3emc_v2.2.0_d -L$(LIBDIR)/w3nco/v2.0.6/intel -lw3nco_v2.0.6_d
+#LIBS   =-L$(TEST) -lnemsio_v2.2.5
 OBJS = read_nemsio.o
 SRCS = read_nemsio.f
 # *************************************************************************

--- a/unit_test/makefile_read_nemsio_theia
+++ b/unit_test/makefile_read_nemsio_theia
@@ -1,11 +1,11 @@
 SHELL   =/bin/sh
 EXEC    =nemsio_read
-NEMSIODIR=/scratch4/NCEPDEV/global/save/Hang.Lei/library/nemsio_v2.2.4
+NEMSIODIR=/scratch4/NCEPDEV/global/save/Hang.Lei/library/nemsio_v2.2.5
 NETCDF=/apps/netcdf/4.3.0-intel
-INCMOD=$(NEMSIODIR)/include/nemsio_v2.2.4
+INCMOD=$(NEMSIODIR)/include/nemsio_v2.2.5
 FC      =  ifort
 FOPTS  = -O -FR -I$(INCMOD)
-LIBS   =-L$(NEMSIODIR) -lnemsio_v2.2.4 -L/scratch3/NCEPDEV/nwprod/lib/bacio/v2.0.1 -lbacio_v2.0.1_4 -L/scratch3/NCEPDEV/nwprod/lib/w3nco/v2.0.6 -lw3nco_v2.0.6_d -L$(NETCDF)/lib -lnetcdff -lnetcdf
+LIBS   =-L$(NEMSIODIR) -lnemsio_v2.2.5 -L/scratch3/NCEPDEV/nwprod/lib/bacio/v2.0.1 -lbacio_v2.0.1_4 -L/scratch3/NCEPDEV/nwprod/lib/w3nco/v2.0.6 -lw3nco_v2.0.6_d -L$(NETCDF)/lib -lnetcdff -lnetcdf
 OBJS = read_nemsio.o
 SRCS = read_nemsio.f
 # *************************************************************************

--- a/unit_test/makefile_read_nemsio_wcoss
+++ b/unit_test/makefile_read_nemsio_wcoss
@@ -5,7 +5,7 @@ TEST=../
 INCMOD=../include/nemsio
 FC      =  ifort
 FOPTS  = -O -FR -I$(INCMOD)
-LIBS   =-L$(LIBDIR) -lnemsio -lbacio_4 -lw3emc_d  -lw3nco_d -L$(TEST) -lnemsio_v2.2.4
+LIBS   =-L$(LIBDIR) -lnemsio -lbacio_4 -lw3emc_d  -lw3nco_d -L$(TEST) -lnemsio_v2.2.5
 OBJS = read_nemsio.o
 SRCS = read_nemsio.f
 # *************************************************************************


### PR DESCRIPTION
Motivation:
The bug868 fix is to address NCO's request on:
Return error code instead of stop in reading empty/false/non nemsio files.
The return code is required to be non-zero.

Tested:
The branch has been tested by unit tests.
It has been submitted to NCO on June/16/2019.
So far, no further requests is made. 